### PR TITLE
doesn't work when root is different

### DIFF
--- a/test/fixture.js
+++ b/test/fixture.js
@@ -1,0 +1,4 @@
+
+
+module.exports = 'a'
+

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,13 @@
+const es6require = require('..');
+const assert = require('assert');
+
+describe('fixture', () => {
+  it('should output the fixture\'s exports', () => {
+
+    // This fails when you simply run mocha (i.e. from the root)
+    assert.equal('a', es6require('./fixture'));
+    // Error: Cannot find module '...root\es6require\fixture'
+    // It tries to load './fixture' from root instead of './test'
+
+  });
+});


### PR DESCRIPTION
I think this doesn't work in all cases. 

It only works when root is the same directory as the file from which require call is made.

Here's a test to repro. Run `mocha` from root. 